### PR TITLE
Fix window event listener cleanup

### DIFF
--- a/src/components/Windows/Windows.js
+++ b/src/components/Windows/Windows.js
@@ -49,21 +49,8 @@ const Window = ({ title, children, onClose, onFocus, forceDefaultSize }) => {
         setSize({ width: size.width + dx, height: size.height + dy });
         setStartCoords({ x: e.clientX, y: e.clientY });
       }
-
-      if (isDragging || isResizing) {
-        window.addEventListener("mousemove", handleMouseMove);
-        window.addEventListener("mouseup", handleMouseUp);
-      } else {
-        window.removeEventListener("mousemove", handleMouseMove);
-        window.removeEventListener("mouseup", handleMouseUp);
-      }
-
-      return () => {
-        window.removeEventListener("mousemove", handleMouseMove);
-        window.removeEventListener("mouseup", handleMouseUp);
-      };
     },
-    [handleMouseUp, isDragging, isResizing, position, size, startCoords]
+    [isDragging, isResizing, position, size, startCoords]
   );
 
   const handleTouchStart = (e) => {


### PR DESCRIPTION
## Summary
- refactor window drag/resize handler
- manage all pointer listener setup/teardown in the `useEffect` hook

## Testing
- `npm test --silent`
- `npm run lint --silent`


------
https://chatgpt.com/codex/tasks/task_e_683f5ea30260832c9e6cec8e13b7de08